### PR TITLE
fix: backup encryption security hardening (V2 format)

### DIFF
--- a/packages/app/lib/page/dbSetup/db_setting.dart
+++ b/packages/app/lib/page/dbSetup/db_setting.dart
@@ -1,46 +1,88 @@
-import 'dart:convert' show jsonDecode, jsonEncode;
-import 'dart:io' show Directory, File;
+import 'dart:convert' show jsonDecode, jsonEncode, utf8;
+import 'dart:io' show Directory, File, Platform;
+import 'dart:math' show Random;
+import 'dart:typed_data' show ByteData, Endian, Uint8List;
+
+import 'package:encrypt/encrypt.dart' as encrypt;
+import 'package:file_picker/file_picker.dart';
+import 'package:hashlib/hashlib.dart';
 import 'package:keychat/service/secure_storage.dart';
 import 'package:keychat/service/storage.dart';
 import 'package:keychat/utils.dart';
-import 'package:encrypt/encrypt.dart' as encrypt;
-import 'package:flutter/services.dart';
-import 'package:file_picker/file_picker.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path/path.dart' as path;
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// V2 backup format magic bytes for format detection.
+const _v2Magic = 'KCBK';
+
+/// V2 format version byte.
+const _v2Version = 0x02;
+
+/// V2 fixed header size: 4 (magic) + 1 (version) + 16 (salt) = 21 bytes.
+/// After this, 2 bytes for metadata length + variable metadata JSON follow.
+const _v2FixedHeaderSize = 21;
+
 class DbSetting {
-  Future<List<File>> getDatabaseFiles(String path) async {
-    final dir = Directory(path);
+  /// Lists non-empty files in the given directory.
+  Future<List<File>> getDatabaseFiles(String dirPath) async {
+    final dir = Directory(dirPath);
     if (!await dir.exists()) {
-      throw Exception('Directory does not exist: $path');
+      throw Exception('Directory does not exist: $dirPath');
     }
 
     return dir
         .listSync()
         .whereType<File>()
-        // need to filter file which is not null
         .where((file) => file.lengthSync() > 0)
         .toList();
   }
 
-  Future<List<Map<String, dynamic>>> encryptFiles(
-    List<File> files,
-    String encryptionKey,
-  ) async {
-    final key = encrypt.Key.fromUtf8(encryptionKey.padRight(32, '0'));
-    final iv = encrypt.IV.fromLength(16);
-    final encrypter = encrypt.Encrypter(encrypt.AES(key));
+  // ---------------------------------------------------------------------------
+  // V2 encryption: Argon2id KDF + in-memory secure data
+  // ---------------------------------------------------------------------------
 
+  /// Derives a 32-byte AES-256 key from password + salt using Argon2id.
+  ///
+  /// Uses OWASP-recommended parameters (47 MB memory, 1 iteration, 1 lane).
+  static Uint8List deriveKeyV2(String password, Uint8List salt) {
+    final result = argon2id(
+      utf8.encode(password),
+      salt,
+      hashLength: 32,
+      security: Argon2Security.owasp,
+    );
+    return Uint8List.fromList(result.bytes);
+  }
+
+  /// Encrypts disk files and in-memory byte entries using a derived key.
+  Future<List<Map<String, dynamic>>> _encryptFilesV2(
+    List<File> diskFiles,
+    List<MapEntry<String, List<int>>> memoryFiles,
+    Uint8List derivedKey,
+  ) async {
+    final key = encrypt.Key(derivedKey);
     final encryptedFiles = <Map<String, dynamic>>[];
 
-    for (final file in files) {
+    for (final file in diskFiles) {
+      final iv = encrypt.IV.fromSecureRandom(16);
       final bytes = await file.readAsBytes();
-
-      final encrypted = encrypter.encryptBytes(bytes, iv: iv);
-
+      final encrypted = encrypt.Encrypter(
+        encrypt.AES(key),
+      ).encryptBytes(bytes, iv: iv);
       encryptedFiles.add({
         'fileName': file.uri.pathSegments.last,
+        'encryptedData': iv.bytes + encrypted.bytes,
+      });
+    }
+
+    for (final entry in memoryFiles) {
+      final iv = encrypt.IV.fromSecureRandom(16);
+      final encrypted = encrypt.Encrypter(
+        encrypt.AES(key),
+      ).encryptBytes(entry.value, iv: iv);
+      encryptedFiles.add({
+        'fileName': entry.key,
         'encryptedData': iv.bytes + encrypted.bytes,
       });
     }
@@ -48,21 +90,63 @@ class DbSetting {
     return encryptedFiles;
   }
 
-  Future<File> packageEncryptedFiles(
+  /// Builds device metadata for the backup header.
+  Future<Map<String, dynamic>> _buildMetadata() async {
+    String appVersion;
+    try {
+      final info = await PackageInfo.fromPlatform();
+      appVersion = '${info.version}+${info.buildNumber}';
+    } catch (_) {
+      appVersion = 'unknown';
+    }
+
+    return {
+      'device': Platform.localHostname,
+      'os': '${Platform.operatingSystem} ${Platform.operatingSystemVersion}',
+      'appVersion': appVersion,
+      'exportedAt': DateTime.now().toUtc().toIso8601String(),
+    };
+  }
+
+  /// Packages encrypted files with the V2 header.
+  ///
+  /// V2 binary layout:
+  /// ```
+  /// KCBK (4) + version (1) + salt (16)
+  /// + metadataLen (2 bytes big-endian) + metadata JSON (variable)
+  /// + [file entries...]
+  /// ```
+  Future<File> _packageEncryptedFilesV2(
     List<Map<String, dynamic>> encryptedFiles,
     String outputPath,
+    Uint8List salt,
+    Map<String, dynamic> metadata,
   ) async {
     final outputFile = File(outputPath);
-
     final sink = outputFile.openWrite();
 
+    // V2 fixed header
+    sink
+      ..add(utf8.encode(_v2Magic))
+      ..add([_v2Version])
+      ..add(salt);
+
+    // Metadata section
+    final metaBytes = utf8.encode(jsonEncode(metadata));
+    final lenBytes = ByteData(2)..setUint16(0, metaBytes.length, Endian.big);
+    sink
+      ..add(lenBytes.buffer.asUint8List())
+      ..add(metaBytes);
+
+    // File entries (same binary structure as V1, but use byte length for names)
     for (final file in encryptedFiles) {
       final fileName = file['fileName'] as String;
+      final fileNameBytes = utf8.encode(fileName);
       final encryptedData = file['encryptedData'] as List<int>;
 
       sink
-        ..write(fileName.length.toString().padLeft(4, '0'))
-        ..write(fileName)
+        ..write(fileNameBytes.length.toString().padLeft(4, '0'))
+        ..add(fileNameBytes)
         ..write(encryptedData.length.toString().padLeft(8, '0'))
         ..add(encryptedData);
     }
@@ -71,58 +155,67 @@ class DbSetting {
     return outputFile;
   }
 
+  /// Exports the database with V2 encryption.
+  ///
+  /// Sensitive data (secure_storage, shared_prefs) is serialized and encrypted
+  /// entirely in memory — no plaintext ever touches disk.
   Future<void> exportDB(String encryptionKey) async {
+    final deviceName = Platform.localHostname.replaceAll(RegExp('[^a-zA-Z0-9_-]'), '_');
     final fileName =
-        'Keychat_db_${formatTime(DateTime.now().millisecondsSinceEpoch, 'yyyy-MM-dd_HH-mm-ss')}';
+        'Keychat_db_${deviceName}_${formatTime(DateTime.now().millisecondsSinceEpoch, 'yyyy-MM-dd_HH-mm-ss')}';
     final sourcePath = '${Utils.appFolder.path}/prod/database';
     final outputPath = '$sourcePath/$fileName';
-    // need export shared_preferences file to sourcePath
-    final sharedPrefsPath = '$sourcePath/shared_prefs_export.json';
-    final exportsharedPrefsFile = File(sharedPrefsPath);
-    await exportSharedPreferences(exportsharedPrefsFile);
-    // need export secure storage file to sourcePath
-    final secureStoragePath = '$sourcePath/secure_storage.json';
-    final exportSecureStorageFile = File(secureStoragePath);
-    await exportSecureStorage(exportSecureStorageFile);
-    await exportAndEncryptDatabases(
-      sourcePath,
-      outputPath,
-      fileName,
-      encryptionKey,
+
+    // 1. Serialize sensitive data to bytes in memory (never written to disk)
+    final secureStorageBytes = utf8.encode(
+      jsonEncode(await SecureStorage.instance.readAll()),
     );
-    // export then delete
-    exportsharedPrefsFile.deleteSync();
-    exportSecureStorageFile.deleteSync();
-  }
+    final sharedPrefsBytes = utf8.encode(
+      jsonEncode(await _getSharedPrefsMap()),
+    );
 
-  Future<void> exportAndEncryptDatabases(
-    String sourcePath,
-    String outputPath,
-    String fileName,
-    String encryptionKey,
-  ) async {
-    try {
-      final files = await getDatabaseFiles(sourcePath);
-      if (files.isEmpty) {
-        logger.e('No database files found at: $sourcePath');
-        return;
-      }
+    final memoryFiles = <MapEntry<String, List<int>>>[
+      MapEntry('secure_storage.json', secureStorageBytes),
+      MapEntry('shared_prefs_export.json', sharedPrefsBytes),
+    ];
 
-      final encryptedFiles = await encryptFiles(files, encryptionKey);
+    // 2. Generate random salt and derive key via Argon2id
+    final salt = Uint8List.fromList(
+      List.generate(16, (_) => Random.secure().nextInt(256)),
+    );
+    final derivedKey = deriveKeyV2(encryptionKey, salt);
 
-      final packagedFile = await packageEncryptedFiles(
-        encryptedFiles,
-        outputPath,
-      );
-      logger.i('Encrypted package created at: ${packagedFile.path}');
+    // 3. Read database files from disk
+    final dbFiles = await getDatabaseFiles(sourcePath);
+    if (dbFiles.isEmpty) {
+      logger.e('No database files found at: $sourcePath');
+      return;
+    }
 
-      await exportFile(packagedFile.path, fileName);
-      if (await packagedFile.exists()) {
-        await packagedFile.delete();
-        logger.i('File deleted: ${packagedFile.path}');
-      }
-    } catch (e) {
-      logger.e('Error occurred: $e');
+    // 4. Encrypt everything
+    final encryptedFiles = await _encryptFilesV2(
+      dbFiles,
+      memoryFiles,
+      derivedKey,
+    );
+
+    // 5. Collect device metadata
+    final metadata = await _buildMetadata();
+
+    // 6. Package with V2 header
+    final packagedFile = await _packageEncryptedFilesV2(
+      encryptedFiles,
+      outputPath,
+      salt,
+      metadata,
+    );
+    logger.i('Encrypted package created at: ${packagedFile.path}');
+
+    // 7. Export via FilePicker
+    await exportFile(packagedFile.path, fileName);
+    if (await packagedFile.exists()) {
+      await packagedFile.delete();
+      logger.i('Temp file deleted: ${packagedFile.path}');
     }
   }
 
@@ -136,34 +229,191 @@ class DbSetting {
     return outputFile != null;
   }
 
-  Future<List<Map<String, dynamic>>> parseEncryptedPackage(
-    String packagePath,
-  ) async {
-    final packageFile = File(packagePath);
-    if (!await packageFile.exists()) {
-      throw Exception('Encrypted package does not exist: $packagePath');
+  // ---------------------------------------------------------------------------
+  // Import: auto-detect V1 / V2 format
+  // ---------------------------------------------------------------------------
+
+  /// Imports a backup with safe rollback.
+  ///
+  /// Decrypts to a temporary directory first. Only replaces the real database
+  /// after decryption succeeds. If decryption fails (wrong password, corrupt
+  /// file, crash), the original data remains intact.
+  Future<bool> importDB(String decryptionKey, File file) async {
+    final sourcePath = '${Utils.appFolder.path}/prod/database/';
+    final tempPath = '${Utils.appFolder.path}/prod/database_import_temp/';
+
+    // 1. Decrypt to a temporary directory first
+    final tempDir = Directory(tempPath);
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+    tempDir.createSync(recursive: true);
+
+    final decryptOk = await _decryptPackageTo(
+      file.path,
+      decryptionKey,
+      tempPath,
+    );
+
+    if (!decryptOk) {
+      // Decryption failed — clean up temp dir, original data untouched
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+      return false;
     }
 
-    final bytes = await packageFile.readAsBytes();
+    // 2. Decryption succeeded — replace original database
+    deleteAllFilesInDirectory(sourcePath);
+    for (final entity in tempDir.listSync()) {
+      if (entity is File) {
+        final destPath = '$sourcePath${entity.uri.pathSegments.last}';
+        entity.copySync(destPath);
+      }
+    }
+
+    // 3. Import shared preferences and secure storage from the restored files
+    await importSharedPreferences(sourcePath);
+    await importSecureStorage(sourcePath);
+
+    // 4. Clean up temp directory
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+
+    return true;
+  }
+
+  /// Decrypts a backup package to [targetDirectory], auto-detecting V1/V2.
+  ///
+  /// Returns true only if all files decrypt successfully.
+  Future<bool> _decryptPackageTo(
+    String packagePath,
+    String decryptionKey,
+    String targetDirectory,
+  ) async {
+    try {
+      final bytes = await File(packagePath).readAsBytes();
+
+      if (_isV2Format(bytes)) {
+        return _decryptV2(bytes, decryptionKey, targetDirectory);
+      } else {
+        return _decryptV1(bytes, decryptionKey, targetDirectory);
+      }
+    } catch (e, s) {
+      logger.e('Import error: $e', stackTrace: s);
+      return false;
+    }
+  }
+
+  /// Returns true if the backup bytes start with the V2 magic header.
+  static bool _isV2Format(Uint8List bytes) {
+    if (bytes.length < _v2FixedHeaderSize) return false;
+    return String.fromCharCodes(bytes.sublist(0, 4)) == _v2Magic;
+  }
+
+  // ---------------------------------------------------------------------------
+  // V2 import
+  // ---------------------------------------------------------------------------
+
+  Future<bool> _decryptV2(
+    Uint8List bytes,
+    String decryptionKey,
+    String targetDirectory,
+  ) async {
+    // Parse fixed header
+    final salt = Uint8List.fromList(bytes.sublist(5, 21));
+    final derivedKey = deriveKeyV2(decryptionKey, salt);
+
+    // Parse metadata section (skip it — used for display only)
+    var offset = _v2FixedHeaderSize;
+    if (offset + 2 > bytes.length) {
+      logger.e('V2 package too short for metadata length.');
+      return false;
+    }
+    final metaLen = ByteData.sublistView(
+      bytes,
+      offset,
+      offset + 2,
+    ).getUint16(0, Endian.big);
+    offset += 2 + metaLen;
+
+    // Log metadata for diagnostics
+    if (metaLen > 0) {
+      try {
+        final metaJson = utf8.decode(bytes.sublist(offset - metaLen, offset));
+        logger.i('Importing backup: $metaJson');
+      } catch (_) {
+        // Metadata is optional, don't fail on parse error
+      }
+    }
+
+    // Parse file entries after header + metadata
+    final encryptedFiles = _parseFileEntries(
+      Uint8List.sublistView(bytes, offset),
+    );
+
+    if (encryptedFiles.isEmpty) {
+      logger.e('No files found in V2 package.');
+      return false;
+    }
+
+    return _decryptAndRestore(
+      encryptedFiles,
+      encrypt.Key(derivedKey),
+      targetDirectory,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // V1 import (legacy compatibility)
+  // ---------------------------------------------------------------------------
+
+  Future<bool> _decryptV1(
+    Uint8List bytes,
+    String decryptionKey,
+    String targetDirectory,
+  ) async {
+    final key = encrypt.Key.fromUtf8(decryptionKey.padRight(32, '0'));
+    final encryptedFiles = _parseFileEntries(bytes);
+
+    if (encryptedFiles.isEmpty) {
+      logger.e('No files found in V1 package.');
+      return false;
+    }
+
+    return _decryptAndRestore(encryptedFiles, key, targetDirectory);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared parse / decrypt helpers
+  // ---------------------------------------------------------------------------
+
+  /// Parses the repeating file-entry structure from raw bytes.
+  List<Map<String, dynamic>> _parseFileEntries(Uint8List bytes) {
     var offset = 0;
     final parsedFiles = <Map<String, dynamic>>[];
 
     while (offset < bytes.length) {
+      if (offset + 4 > bytes.length) break;
       final fileNameLength = int.parse(
         String.fromCharCodes(bytes.sublist(offset, offset + 4)),
       );
       offset += 4;
 
-      final fileName = String.fromCharCodes(
+      if (offset + fileNameLength > bytes.length) break;
+      final fileName = utf8.decode(
         bytes.sublist(offset, offset + fileNameLength),
       );
       offset += fileNameLength;
 
+      if (offset + 8 > bytes.length) break;
       final dataLength = int.parse(
         String.fromCharCodes(bytes.sublist(offset, offset + 8)),
       );
       offset += 8;
 
+      if (offset + dataLength > bytes.length) break;
       final encryptedData = bytes.sublist(offset, offset + dataLength);
       offset += dataLength;
 
@@ -176,12 +426,15 @@ class DbSetting {
     return parsedFiles;
   }
 
-  Future<bool> decryptAndSaveFiles(
+  /// Decrypts file entries and writes them to the target directory.
+  ///
+  /// Does NOT import shared preferences or secure storage — the caller is
+  /// responsible for that after verifying decryption succeeded.
+  Future<bool> _decryptAndRestore(
     List<Map<String, dynamic>> encryptedFiles,
-    String decryptionKey,
+    encrypt.Key key,
     String targetDirectory,
   ) async {
-    final key = encrypt.Key.fromUtf8(decryptionKey.padRight(32, '0'));
     final encrypter = encrypt.Encrypter(encrypt.AES(key));
 
     try {
@@ -200,50 +453,26 @@ class DbSetting {
         final targetFile = File('$targetDirectory$fileName');
         await targetFile.writeAsBytes(decrypted);
       }
-      // parse sharedPreferences data
-      await importSharedPreferences(targetDirectory);
-      await importSecureStorage(targetDirectory);
+
       return true;
     } catch (e, s) {
-      logger.e('Error occurred: $e', stackTrace: s);
+      logger.e('Decryption error: $e', stackTrace: s);
       return false;
     }
   }
 
-  Future<bool> importAndDecryptPackage(
-    String packagePath,
-    String decryptionKey,
-    String targetDirectory,
-  ) async {
-    try {
-      final encryptedFiles = await parseEncryptedPackage(packagePath);
-
-      if (encryptedFiles.isEmpty) {
-        logger.e('No files found in the encrypted package.');
-        return false;
-      }
-      logger.i('Files successfully decrypted to: $targetDirectory');
-
-      return await decryptAndSaveFiles(
-        encryptedFiles,
-        decryptionKey,
-        targetDirectory,
-      );
-    } catch (e) {
-      logger.e('Error occurred: $e');
-      return false;
-    }
-  }
+  // ---------------------------------------------------------------------------
+  // Utility methods
+  // ---------------------------------------------------------------------------
 
   void deleteAllFilesInDirectory(String targetDirectory) {
     final directory = Directory(targetDirectory);
 
     if (directory.existsSync()) {
-      // List all the entities in the directory
       directory.listSync().forEach((entity) {
         if (entity is File) {
           try {
-            entity.deleteSync(); // Delete the file
+            entity.deleteSync();
           } catch (e) {
             logger.e('Error deleting file: ${entity.path}, $e');
           }
@@ -252,15 +481,8 @@ class DbSetting {
       logger.i('All files in $targetDirectory have been deleted.');
     } else {
       logger.e('Directory does not exist then create: $targetDirectory');
-      // path need to create
       directory.createSync(recursive: true);
     }
-  }
-
-  Future<bool> importDB(String decryptionKey, File file) async {
-    final sourcePath = '${Utils.appFolder.path}/prod/database/';
-    deleteAllFilesInDirectory(sourcePath);
-    return importAndDecryptPackage(file.path, decryptionKey, sourcePath);
   }
 
   Future<File?> importFile() async {
@@ -271,74 +493,45 @@ class DbSetting {
     return null;
   }
 
+  /// Returns shared preferences as a JSON-serializable map.
+  Future<Map<String, dynamic>> _getSharedPrefsMap() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getKeys().fold<Map<String, dynamic>>({}, (map, key) {
+      map[key] = prefs.get(key);
+      return map;
+    });
+  }
+
   Future<void> importSharedPreferences(String importFilePath) async {
     try {
-      // first clear old data
       await Storage.clearAll();
       final file = File('$importFilePath/shared_prefs_export.json');
       final jsonString = await file.readAsString();
       final data = jsonDecode(jsonString) as Map<String, dynamic>;
 
-      data.forEach((key, value) async {
+      for (final entry in data.entries) {
+        final key = entry.key;
+        final value = entry.value;
         if (value is int) {
           await Storage.setInt(key, value);
-        }
-        // else if (value is double) {
-        // await Storage.setDouble(key, value);
-        // }
-        else if (value is bool) {
+        } else if (value is bool) {
           await Storage.setBool(key, value);
         } else if (value is String) {
           await Storage.setString(key, value);
         } else if (value is List<String>) {
           await Storage.setStringList(key, value);
         }
-      });
-      // load then delete
-      file.deleteSync();
+      }
 
+      file.deleteSync();
       logger.i('Shared preferences imported.');
     } catch (e) {
-      logger.e('Error importing data: $e');
-    }
-  }
-
-  // first create a file in below path:
-  // String sourcePath = '${appFolder.path}/prod/database/';
-  Future<void> exportSharedPreferences(File exportFile) async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final data = prefs.getKeys().fold({}, (map, key) {
-        map[key] = prefs.get(key);
-        return map;
-      });
-
-      final jsonString = jsonEncode(data);
-      await exportFile.writeAsString(jsonString);
-
-      logger.i('Exported to: ${exportFile.path}');
-    } catch (e) {
-      logger.e('Error exporting data: $e');
-    }
-  }
-
-  Future<void> exportSecureStorage(File exportFile) async {
-    try {
-      final allData = await SecureStorage.instance.readAll();
-
-      final jsonData = jsonEncode(allData);
-
-      await exportFile.writeAsString(jsonData);
-
-      logger.i('Data exported to ${exportFile.path}');
-    } catch (e) {
-      logger.e('Error exporting data: $e');
+      logger.e('Error importing shared preferences: $e');
     }
   }
 
   Future<void> importSecureStorage(String importFilePath) async {
     try {
-      // first clear old data
       await SecureStorage.instance.clearAll();
       final filePath = '${importFilePath}secure_storage.json';
 
@@ -349,16 +542,36 @@ class DbSetting {
         jsonDecode(jsonData) as Map<String, dynamic>,
       );
 
-      // write secure storage
       for (final entry in allData.entries) {
         await SecureStorage.instance.write(entry.key, entry.value);
       }
-      // load then delete
-      file.deleteSync();
 
-      logger.i('Data imported from $filePath');
+      file.deleteSync();
+      logger.i('Secure storage imported from $filePath');
     } catch (e) {
-      logger.e('Error importing data: $e');
+      logger.e('Error importing secure storage: $e');
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Password strength validation
+  // ---------------------------------------------------------------------------
+
+  /// Validates password meets minimum strength requirements.
+  /// Returns an error message string, or null if the password is acceptable.
+  static String? validatePasswordStrength(String password) {
+    if (password.length < 8) {
+      return 'Password must be at least 8 characters';
+    }
+    if (!password.contains(RegExp('[A-Z]'))) {
+      return 'Password must contain an uppercase letter';
+    }
+    if (!password.contains(RegExp('[a-z]'))) {
+      return 'Password must contain a lowercase letter';
+    }
+    if (!password.contains(RegExp('[0-9]'))) {
+      return 'Password must contain a digit';
+    }
+    return null;
   }
 }

--- a/packages/app/lib/page/setting/app_general_setting.dart
+++ b/packages/app/lib/page/setting/app_general_setting.dart
@@ -434,6 +434,7 @@ class _AppGeneralSettingState extends State<AppGeneralSetting> {
                 autofocus: true,
                 decoration: const InputDecoration(
                   labelText: 'Password',
+                  helperText: '8+ chars: A-Z, a-z, 0-9',
                   border: OutlineInputBorder(),
                 ),
               ),
@@ -458,8 +459,15 @@ class _AppGeneralSettingState extends State<AppGeneralSetting> {
           CupertinoActionSheetAction(
             isDefaultAction: true,
             onPressed: () async {
-              if (passwordController.text.isNotEmpty &&
-                  passwordController.text != confirmPasswordController.text) {
+              final password = passwordController.text;
+              final strengthError = DbSetting.validatePasswordStrength(
+                password,
+              );
+              if (strengthError != null) {
+                EasyLoading.showError(strengthError);
+                return;
+              }
+              if (password != confirmPasswordController.text) {
                 EasyLoading.showError('Passwords do not match');
                 return;
               }

--- a/packages/app/lib/service/file.service.dart
+++ b/packages/app/lib/service/file.service.dart
@@ -1,6 +1,5 @@
 import 'dart:convert' show base64Encode, utf8;
 import 'dart:io' show Directory, File;
-import 'dart:math' show Random;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:keychat/controller/setting.controller.dart';
@@ -13,7 +12,6 @@ import 'package:keychat/service/message.service.dart';
 import 'package:keychat/service/room.service.dart';
 import 'package:keychat/service/s3.dart';
 import 'package:keychat/utils.dart';
-import 'package:keychat/utils/config.dart';
 import 'package:dio/dio.dart';
 import 'package:easy_debounce/easy_throttle.dart';
 import 'package:encrypt/encrypt.dart';
@@ -555,8 +553,7 @@ class FileService {
     bool base64Hash = false,
   }) async {
     final iv = IV.fromSecureRandom(16);
-    final salt = SecureRandom(16).bytes;
-    final key = Key.fromSecureRandom(32).stretch(32, salt: salt);
+    final key = Key.fromSecureRandom(32);
     final encrypter = Encrypter(AES(key, mode: AESMode.ctr));
     final fileName = path.basename(input.path);
     final encryptedBytes = encrypter.encryptBytes(

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -70,6 +70,7 @@ dependencies:
   url_launcher: ^6.3.2
   flutter_inappwebview: 6.2.0-beta.2
   encrypt: ^5.0.3
+  hashlib: ^2.3.0
   file_picker: ^10.3.7
   image: ^4.5.2
   pub_semver: ^2.1.5

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -287,10 +287,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -339,14 +339,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  code_assets:
-    dependency: transitive
-    description:
-      name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   code_builder:
     dependency: transitive
     description:
@@ -1041,6 +1033,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  hashlib:
+    dependency: transitive
+    description:
+      name: hashlib
+      sha256: b12381c77d926cc1a55a6c1dbf6fbbc5c97c05b670e89f6ce3bc59fc673f9dd2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  hashlib_codecs:
+    dependency: transitive
+    description:
+      name: hashlib_codecs
+      sha256: "0e1a17c47792fd131a9bf49b811c394b22516287746ee14cd0b0c22a34136699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   highlight:
     dependency: transitive
     description:
@@ -1049,14 +1057,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
-  hooks:
-    dependency: transitive
-    description:
-      name: hooks
-      sha256: "7a08a0d684cb3b8fb604b78455d5d352f502b68079f7b80b831c62220ab0a4f6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   html:
     dependency: transitive
     description:
@@ -1370,18 +1370,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   melos:
     dependency: "direct dev"
     description:
@@ -1430,14 +1430,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.4"
   nested:
     dependency: transitive
     description:
@@ -1462,14 +1454,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.0"
   octo_image:
     dependency: transitive
     description:
@@ -1546,10 +1530,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.5.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -2128,26 +2112,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:
@@ -2360,10 +2344,10 @@ packages:
     dependency: "direct dev"
     description:
       name: very_good_analysis
-      sha256: d1cb1d66a5aae2c702d68caca6c8347306d35e728fd94555fa21fa0448a972e0
+      sha256: "27927d1140ce1b140f998b6340f730a626faa5b95110b3e34a238ff254d731d0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.1.0"
   video_compress:
     dependency: transitive
     description:
@@ -2565,5 +2549,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.1"


### PR DESCRIPTION
- Add Argon2id KDF (hashlib) replacing insecure padRight(32,'0') key derivation
- Add V2 backup format with KCBK magic header, salt, device metadata
- Encrypt secure_storage in memory (no plaintext written to disk)
- Safe import with rollback: decrypt to temp dir before replacing data
- Add password strength validation (8+ chars, A-Z, a-z, 0-9)
- Fix insecure Random(16).nextInt(10) in file.service.dart with Key.fromSecureRandom(32)
- Fix unicode filename byte length mismatch in file entry packing/parsing
- Add device name to export filename for multi-device identification
- Maintain full V1 backward compatibility for importing old backups